### PR TITLE
Add changelog to release notes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,15 @@ before_deploy:
     else
       git tag $TRAVIS_TAG -a -m "Generated tag from TravisCI for build $TRAVIS_BUILD_NUMBER"
     fi
+  - source get_changelog.sh
 
 deploy:
   - provider: releases  # use Github pages instead: pages 
     token: $GITHUB_TOKEN
     file_glob: true # enable wild cards '*'
     file: dist/*.whl
+    name: $RELEASE_NAME
+    body: $RELEASE_BODY
     skip_cleanup: true
     overwrite: true
     on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Pedantic 1.14.3
+- added release notes to GitHub releases (CI)
+
 ## Pedantic 1.14.2
 - allow async functions for `@in_subprocess`
 - use Pipe instead of Queue for subprocess communication

--- a/get_changelog.sh
+++ b/get_changelog.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+SEARCH_TERM="## Pedantic"
+# get line number of latest Release Header
+FROM=$(
+# get lines with the string <## Pedantic> in it (Header lines) together with line numbers
+grep "${SEARCH_TERM}" CHANGELOG.md --line-number |
+  # only take the first occurance
+  head -n 1 |
+  # only keep the line numbers 
+  sed 's/\(.*\):.*/\1/' 
+)
+
+# get line number of second latest Release Header
+TO=$(
+# same as above
+grep "${SEARCH_TERM}" CHANGELOG.md --line-number |
+  # take the last of the first two lines
+  head -n 2 |
+  tail -n 1 |
+  # same as above
+  sed 's/\(.*\):.*/\1/' 
+)
+
+echo "Take lines ${FROM} - ${TO}"
+
+export RELEASE_BODY=$(
+# take content from changelog
+cat CHANGELOG.md |
+  # take from [0, TO - 1] (-1 to exclude second latest release header)
+  head -n $((TO - 1)) |
+  # take the last TO - 1 - FROM lines to get the content of the latest release
+  # this cuts away the first few lines before the latest release header
+  tail -n $((TO - FROM - 1))
+)
+
+export RELEASE_NAME=$(
+# same as above
+cat CHANGELOG.md |
+  head -n $((TO - 1)) |
+  # throw away the body and only keep the header
+  tail -n $((TO - FROM)) |
+  head -n 1
+)
+
+echo "Found Release Details:"
+echo ""
+echo "${RELEASE_NAME}"
+echo ""
+echo "${RELEASE_BODY}"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ author = "Willi Sontopski"
 
 setup(
     name="pedantic",
-    version="1.14.2",
+    version="1.14.3",
     python_requires='>=3.7.0',
     packages=find_packages(),
     install_requires=[],


### PR DESCRIPTION
This PR

- adds shell script which exports details to environment variables, given the changelog format won't change (!)
- uses options mentioned [here](https://docs.travis-ci.com/user/deployment/releases/#advanced-options) to modify name and body of github release

---

There are a few things that might not work because I'm also unsure if travis can handle them:

- CLI programs used in the script `get_changelog.sh` could be missing. I used `grep`, `cat`, `sed`, `head`, `tail` which are normally chore utils on every unix installation
- The environment variables that are exported in the scripts could be unavailable in the `travis.yml` deploy section

I don't have any chance to test these changes myself unfortunately. Maybe just try them out and disable `PyPi` releases for the test releases :sweat_smile:
