### PR TITLE
Add conda-forge install instructions and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Pedantic 1.16.2
+- [add conda-forge install instructions and version](https://github.com/LostInDarkMath/pedantic-python-decorators/pull/93)
+
 ## Pedantic 1.16.1
 - bump `flask` and `werkzeug` to version `3.0.0`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pedantic-python-decorators [![Build Status](https://travis-ci.com/LostInDarkMath/pedantic-python-decorators.svg?branch=master)](https://travis-ci.com/LostInDarkMath/pedantic-python-decorators)  [![Coverage Status](https://coveralls.io/repos/github/LostInDarkMath/pedantic-python-decorators/badge.svg?branch=master)](https://coveralls.io/github/LostInDarkMath/pedantic-python-decorators?branch=master) [![PyPI version](https://badge.fury.io/py/pedantic.svg)](https://badge.fury.io/py/pedantic) [![Last Commit](https://badgen.net/github/last-commit/LostInDarkMath/pedantic-python-decorators?color=green)](https://GitHub.com/LostInDarkMath/pedantic-python-decorators) [![Stars](https://badgen.net/github/stars/LostInDarkMath/pedantic-python-decorators?color=green)](https://GitHub.com/LostInDarkMath/pedantic-python-decorators) [![Open Issues](https://badgen.net/github/open-issues/LostInDarkMath/pedantic-python-decorators?color=green)](https://GitHub.com/LostInDarkMath/pedantic-python-decorators/issues) [![Open PRs](https://badgen.net/github/open-prs/LostInDarkMath/pedantic-python-decorators?color=green)](https://GitHub.com/LostInDarkMath/pedantic-python-decorators/pulls)
+# pedantic-python-decorators [![Build Status](https://travis-ci.com/LostInDarkMath/pedantic-python-decorators.svg?branch=master)](https://travis-ci.com/LostInDarkMath/pedantic-python-decorators)  [![Coverage Status](https://coveralls.io/repos/github/LostInDarkMath/pedantic-python-decorators/badge.svg?branch=master)](https://coveralls.io/github/LostInDarkMath/pedantic-python-decorators?branch=master) [![PyPI version](https://badge.fury.io/py/pedantic.svg)](https://badge.fury.io/py/pedantic) [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pedantic.svg)](https://anaconda.org/conda-forge/pedantic) [![Last Commit](https://badgen.net/github/last-commit/LostInDarkMath/pedantic-python-decorators?color=green)](https://GitHub.com/LostInDarkMath/pedantic-python-decorators) [![Stars](https://badgen.net/github/stars/LostInDarkMath/pedantic-python-decorators?color=green)](https://GitHub.com/LostInDarkMath/pedantic-python-decorators) [![Open Issues](https://badgen.net/github/open-issues/LostInDarkMath/pedantic-python-decorators?color=green)](https://GitHub.com/LostInDarkMath/pedantic-python-decorators/issues) [![Open PRs](https://badgen.net/github/open-prs/LostInDarkMath/pedantic-python-decorators?color=green)](https://GitHub.com/LostInDarkMath/pedantic-python-decorators/pulls)
 
 This packages includes many decorators that will make you write cleaner Python code. 
 
@@ -9,11 +9,14 @@ There are multiple options for installing this package.
 ### Option 1: Installing with pip from [Pypi](https://pypi.org/)
 Run `pip install pedantic`.
 
-### Option 2: Installing with pip and git
+### Option 2: Installing with conda from [conda-forge](conda-forge.org)
+Run `conda install -c conda-forge pedantic`
+
+### Option 3: Installing with pip and git
 1. Install [Git](https://git-scm.com/downloads) if you don't have it already.
 2. Run `pip install git+https://github.com/LostInDarkMath/pedantic-python-decorators.git@master`
 
-### Option 3: Offline installation using wheel
+### Option 4: Offline installation using wheel
 1. Download the [latest release here](https://github.com/LostInDarkMath/PythonHelpers/releases/latest) by clicking on `pedantic-python-decorators-x.y.z-py-none-any.whl`.
 2. Execute `pip install pedantic-python-decorators-x.y.z-py3-none-any.whl`.
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ author = "Willi Sontopski"
 
 setup(
     name="pedantic",
-    version="1.16.1",
+    version="1.16.2",
     python_requires='>=3.9.0',
     packages=find_packages(),
     install_requires=[],


### PR DESCRIPTION
I've added instructions for how to install the package from conda-forge as well as a badge that shows the version of the package on conda-forge. Let me what you think! No worries if you don't want to point users to installing from conda-forge.  